### PR TITLE
Fix compiler lint args ignored; maven adds -nowarn by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
+                    <showWarnings>true</showWarnings>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                         <arg>-Werror</arg>


### PR DESCRIPTION
https://stackoverflow.com/questions/35247099/xlintrawtypes-not-working-in-maven